### PR TITLE
change "web" to "url" to appease npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/DavidDurman/statechart.git"
   },
   "bugs": {
-    "web": "http://github.com/DavidDurman/statechart/issues/",
+    "url": "http://github.com/DavidDurman/statechart/issues/",
     "mail": "daviddurman@gmail.com"
   },
   "directories": {


### PR DESCRIPTION
was getting this when installing

``` bash
npm WARN package.json statechart@0.1.1 bugs['web'] should probably be bugs['url'].
```
